### PR TITLE
HARMONY-901: Require a version of numcodecs compatible with shuffle filter decoding

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests-futures>=1.0.0
 zarr>=2.7.1
 ipypb~=0.5
 xarray~=0.16
+numcodecs>=0.8.1


### PR DESCRIPTION
To test:
Install an older version of numcodecs into your kernel (`pip install numcodecs=2.7.3`)
`pip install -e .`
Verify that the latest version gets installed (0.8.1 or greater).

Optional: verify the demo notebook works, as it relies on the newer version.