### PR TITLE
Fix critical severity vulnerability introduced via matplotlib.

### DIFF
--- a/presentation/requirements.txt
+++ b/presentation/requirements.txt
@@ -1,2 +1,2 @@
-matplotlib>=3.4.1
-h5py>=3.2.1
+matplotlib>=3.8.0
+h5py>=3.9.0


### PR DESCRIPTION
This PR fixes a vulnerability reported by Snyk. `pillow`, which is a dependency of `matplotlib` needs to be updated (see report [here](https://app.snyk.io/org/esdis-cumulus-core-gibs-cmr-etc./project/a91e1beb-0c25-45bf-8da6-9ab6075b080a)).

The reported vulnerability has a critical severity.