### PR TITLE
HARMONY-1658: Do not pin the version of xarray.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ requests>=2.23.0
 requests-futures>=1.0.0
 zarr>=2.7.1
 ipypb~=0.5
-xarray~=0.16
+xarray>=0.16
 numcodecs>=0.8.1


### PR DESCRIPTION
## Jira Issue ID
Harmony-1658

## Description
Do not pin the version of xarray. Users that wanted to install the zarr-eosdis-store were seeing xarray downgraded in their python environment, but they needed a later version of xarray for other libraries in their environment.

## Local Test Steps
As far as I can tell there was no reason xarray was pinned, however this repo has several failing tests at the moment. The root cause of those failures is that the tests were relying on files that no longer exist. We'll need to figure out how to reconstruct those missing files and ensure in the future they are under our control and cannot be removed.

I did verify that with the latest version of xarray there are no new test failures - everything passing continues to pass.

To test:
1. Set your python environment
2. pip install -r requirements.txt
3. pip install -r requirements-dev.txt
4. pip install xarray --upgrade
5. Verify that your version of xarray is the latest (2024.1.1)
6. pip install -r requirements.txt
7. Verify that xarray is not downgraded
8. coverage run -m pytest
9. Verify that 4 of 14 tests pass