### PR TITLE
HARMONY-2062: Update the development status classifier to show the project is inactive

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     url="https://github.com/nasa/zarr-eosdis-store",
     packages=find_packages(exclude=['docs', 'tests*']),
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 7 - Inactive',
         'Intended Audience :: Developers',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
The classifier is shown on the PyPi page as another way of letting others know the project is no longer maintained.